### PR TITLE
Fix repository names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install via composer
 
 ```
-composer require bratucornel/magento-2-romanian-language-pack:dev-master
+composer require bajula/magento-2-romanian-language-pack:dev-master
 ```
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "bratucornel/magento-2-romanian-language-pack",
+  "name": "bajula/magento-2-romanian-language-pack",
   "description": "Romanian language package for Magento 2",
   "type": "magento2-language",
   "version": "1.0.0",


### PR DESCRIPTION
This commit fixes the repository name after the move from brautcornel to
bajula. Without this fix the lang-pack can't be installed.